### PR TITLE
Change method signature to void

### DIFF
--- a/src/main/java/com/bloomreach/bstore/highavailability/actions/CloneAliasesAction.java
+++ b/src/main/java/com/bloomreach/bstore/highavailability/actions/CloneAliasesAction.java
@@ -41,7 +41,7 @@ public class CloneAliasesAction extends SolrFaultTolerantAction {
   }
 
   @Override
-  public boolean executeAction() throws Exception {
+  public void executeAction() throws Exception {
     //Fetch all source aliases
     LinkedHashMap<String, String> sourceAliases = sourceZKClient.getZkClusterData().getAliases();
     LinkedHashMap<String, String> destinationAliases = destinationZKClient.getZkClusterData().getAliases();
@@ -73,7 +73,6 @@ public class CloneAliasesAction extends SolrFaultTolerantAction {
       SolrInteractionUtils.createAlias(destionationHost, alias, destinationCollectionName);
     }
 
-    boolean missingAliases = false;
     //Only if anything has changed in the source zookeeper, do the verification
     if (dirty) {
       //Refresh Zookeeper view to verify if all aliases are good
@@ -85,11 +84,8 @@ public class CloneAliasesAction extends SolrFaultTolerantAction {
           logger.info("Alias " + alias + "exists on the destination cluster also...");
         } else {
           logger.error("Alias " + alias + "DOES NOT EXIST on the destination cluster. Please investigate.....");
-          missingAliases = true;
         }
       }
     }
-
-    return missingAliases;
   }
 }

--- a/src/main/java/com/bloomreach/bstore/highavailability/actions/CloneCollectionsAction.java
+++ b/src/main/java/com/bloomreach/bstore/highavailability/actions/CloneCollectionsAction.java
@@ -56,7 +56,7 @@ public class CloneCollectionsAction extends SolrFaultTolerantAction {
   }
 
   @Override
-  public boolean executeAction() throws Exception {
+  public void executeAction() throws Exception {
     List<String> operationalCollections = config.getCollections();
 
     if (operationalCollections.size() == 0) {
@@ -88,7 +88,6 @@ public class CloneCollectionsAction extends SolrFaultTolerantAction {
 
     ReplicationManger replicationManger = new ReplicationManger(replicatorConfig);
     replicationManger.replicateCollections();
-    boolean collectionsStreamed = replicationManger.monitorReplicationRequests();
 
     List<ReplicationDiagnostics> allDiagnostics = replicationManger.getAllDiagnostics();
 
@@ -103,9 +102,6 @@ public class CloneCollectionsAction extends SolrFaultTolerantAction {
                 "-> " + diagnostic.getTimeElapsed() + ". Percentage ->" + diagnostic.getPercentageComplete());
       }
     }
-
-    return collectionsStreamed && (allDiagnostics.size() == 0);
-
   }
 
   /**

--- a/src/main/java/com/bloomreach/bstore/highavailability/actions/CloneZkConfigsAction.java
+++ b/src/main/java/com/bloomreach/bstore/highavailability/actions/CloneZkConfigsAction.java
@@ -51,7 +51,7 @@ public class CloneZkConfigsAction extends SolrFaultTolerantAction {
   }
 
   @Override
-  public boolean executeAction() throws Exception {
+  public void executeAction() throws Exception {
     String sourceZk = config.getZkHost();
     String destinationZk = config.getDestinationZkHost();
 
@@ -67,6 +67,5 @@ public class CloneZkConfigsAction extends SolrFaultTolerantAction {
     //Replicate the data
     ZookeeperDataReplicator replicator = new ZookeeperDataReplicator(destinationZk, CONFIG_PATH, rootNode);
     replicator.replicate();
-    return true;
   }
 }

--- a/src/main/java/com/bloomreach/bstore/highavailability/actions/SmokeTestClusterAction.java
+++ b/src/main/java/com/bloomreach/bstore/highavailability/actions/SmokeTestClusterAction.java
@@ -41,7 +41,7 @@ public class SmokeTestClusterAction extends SolrFaultTolerantAction {
   }
 
   @Override
-  public boolean executeAction() throws Exception {
+  public void executeAction() throws Exception {
 
     LinkedHashMap<String, String> destionationAliases = destinationZKClient.getZkClusterData().getAliases();
     String destinationSolrHost = destinationZKClient.getZkClusterData().getSolrHosts().toArray()[0].toString();
@@ -83,7 +83,5 @@ public class SmokeTestClusterAction extends SolrFaultTolerantAction {
     if (isClusterHealthy) {
       logger.info("Cluster is healthy...");
     }
-
-    return true;
   }
 }

--- a/src/main/java/com/bloomreach/bstore/highavailability/actions/SolrDeleteCollectionAction.java
+++ b/src/main/java/com/bloomreach/bstore/highavailability/actions/SolrDeleteCollectionAction.java
@@ -31,21 +31,17 @@ public class SolrDeleteCollectionAction extends SolrFaultTolerantAction {
   }
 
   @Override
-  public boolean executeAction() throws Exception {
-    String solrHost = (String) sourceZKClient.getZkClusterData().getSolrHosts().toArray()[0];
-
-    List<String> collections;
-
+  public void executeAction() throws Exception {
     if (config.getCollections().size() == 0) {
       logger.info("No collections passed.. Returning");
-      return true;
-    } else {
-      collections = config.getCollections();
+      return;
     }
+    String solrHost = (String) sourceZKClient.getZkClusterData().getSolrHosts().toArray()[0];
+
+    List<String> collections = config.getCollections();
     String logMessage = "Deleting collections %s on %s";
     logger.info(String.format(logMessage, Arrays.toString(collections.toArray()), solrHost));
 
-    boolean succesfulDelete = true;
     //Delete the collection
     for (String collectionName : collections) {
       if (collectionName.equals("collection1")) {
@@ -57,10 +53,7 @@ public class SolrDeleteCollectionAction extends SolrFaultTolerantAction {
         SolrInteractionUtils.deleteCollection(solrHost, collectionName);
       } catch (Exception e) {
         logger.info("Delete collection failed for " + collectionName);
-        succesfulDelete = false;
       }
     }
-
-    return succesfulDelete;
   }
 }

--- a/src/main/java/com/bloomreach/bstore/highavailability/actions/SolrFaultTolerantAction.java
+++ b/src/main/java/com/bloomreach/bstore/highavailability/actions/SolrFaultTolerantAction.java
@@ -53,5 +53,5 @@ public abstract class SolrFaultTolerantAction {
    *
    * @throws Exception
    */
-  public abstract boolean executeAction() throws Exception;
+  public abstract void executeAction() throws Exception;
 }


### PR DESCRIPTION
I don't see the `boolean` return type of `executeAction` in `SolrFaultTolerantAction` being used. The method was being used like void so I have changed the method signature to have `void` return type.

So either the return type has to be changed to void or it should be used for something.
